### PR TITLE
Remove all traces of CMMN which we don't want to support.

### DIFF
--- a/micronaut-camunda-bpm-feature/build.gradle
+++ b/micronaut-camunda-bpm-feature/build.gradle
@@ -22,7 +22,9 @@ micronaut {
 dependencies {
     implementation("io.micronaut:micronaut-validation")
     implementation("io.micronaut:micronaut-runtime")
-    api("org.camunda.bpm:camunda-engine:$camundaVersion")
+    api("org.camunda.bpm:camunda-engine:$camundaVersion") {
+        exclude group: 'org.camunda.bpm.model', module: 'camunda-cmmn-model'
+    }
 
     compileOnly("io.micronaut.servlet:micronaut-servlet-engine")
     compileOnly("io.micronaut:micronaut-http-server-netty")

--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/CamundaServicesFactory.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/CamundaServicesFactory.java
@@ -73,17 +73,6 @@ public class CamundaServicesFactory {
     }
 
     /**
-     * Creates a bean for the {@link CaseService} in the application context which can be injected if needed.
-     *
-     * @param processEngine the {@link ProcessEngine}
-     * @return the {@link CaseService}
-     */
-    @Singleton
-    public CaseService caseService(ProcessEngine processEngine) {
-        return processEngine.getCaseService();
-    }
-
-    /**
      * Creates a bean for the {@link DecisionService} in the application context which can be injected if needed.
      *
      * @param processEngine the {@link ProcessEngine}

--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/DefaultPropertySourceLoader.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/DefaultPropertySourceLoader.java
@@ -58,6 +58,7 @@ public class DefaultPropertySourceLoader implements PropertySourceLoader {
                         new HashMap<String, Object>() {{
                             put("datasources.default.maximum-pool-size", MAXIMUM_POOL_SIZE);
                             put("datasources.default.minimum-idle", MINIMUM_POOL_SIZE);
+                            put("camunda.generic-properties.properties.cmmn-enabled", false);
                         }}, POSITION));
     }
 

--- a/micronaut-camunda-bpm-feature/src/test/kotlin/info/novatec/micronaut/camunda/bpm/feature/test/CamundaServicesFactoryTest.kt
+++ b/micronaut-camunda-bpm-feature/src/test/kotlin/info/novatec/micronaut/camunda/bpm/feature/test/CamundaServicesFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 original authors
+ * Copyright 2020-2022 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,20 @@
  */
 package info.novatec.micronaut.camunda.bpm.feature.test
 
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
 import org.camunda.bpm.engine.*
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
 @MicronautTest
 class CamundaServicesFactoryTest {
+    @Inject
+    lateinit var applicationContext: ApplicationContext
+
     @Inject
     lateinit var runtimeService: RuntimeService
 
@@ -34,9 +40,6 @@ class CamundaServicesFactoryTest {
 
     @Inject
     lateinit var authorizationService: AuthorizationService
-
-    @Inject
-    lateinit var caseService: CaseService
 
     @Inject
     lateinit var decisionService: DecisionService
@@ -65,7 +68,6 @@ class CamundaServicesFactoryTest {
         assertNotNull(repositoryService)
         assertNotNull(managementService)
         assertNotNull(authorizationService)
-        assertNotNull(caseService)
         assertNotNull(decisionService)
         assertNotNull(externalTaskService)
         assertNotNull(filterService)
@@ -73,5 +75,12 @@ class CamundaServicesFactoryTest {
         assertNotNull(taskService)
         assertNotNull(historyService)
         assertNotNull(identityService)
+    }
+
+    @Test
+    fun `CaseService is not supported`() {
+        Assertions.assertThrows(NoSuchBeanException::class.java) {
+            applicationContext.getBean(CaseService::class.java)
+        }
     }
 }


### PR DESCRIPTION
This saves about 50 to 100 ms on startup.